### PR TITLE
Use floor division instead of regular division for 69. Sqrt(x)

### DIFF
--- a/Python/sqrtx.py
+++ b/Python/sqrtx.py
@@ -14,9 +14,9 @@ class Solution(object):
         if x < 2:
             return x
         
-        left, right = 1, x / 2
+        left, right = 1, x // 2
         while left <= right:
-            mid = left + (right - left) / 2
+            mid = left + (right - left) // 2
             if mid > x / mid:
                 right = mid - 1
             else:


### PR DESCRIPTION
print Solution().sqrt(9) gave me 2.75, which should be 3.