### PR TITLE
Fix to create a complete BST

### DIFF
--- a/Python/convert-sorted-array-to-binary-search-tree.py
+++ b/Python/convert-sorted-array-to-binary-search-tree.py
@@ -17,10 +17,27 @@ class Solution:
     def sortedArrayToBST(self, num):
         return self.sortedArrayToBSTRecu(num, 0, len(num))
     
+    @staticmethod
+    def perfect_tree_pivot(n):
+        """
+        Find the point to partition n keys for a perfect binary search tree
+        """
+        x = 1
+        # find a power of 2 <= n//2
+        # while x <= n//2:  # this loop could probably be written more elegantly :)
+        #     x *= 2
+        x = 1 << (n.bit_length() - 1)  # use the left bit shift, same as multiplying x by 2**n-1
+
+        if x // 2 - 1 <= (n - x):
+            return x - 1  # case 1: the left subtree of the root is perfect and the right subtree has less nodes
+        else:
+            return n - x // 2  # case 2 == n - (x//2 - 1) - 1 : the left subtree of the root
+                               # has more nodes and the right subtree is perfect.
+    
     def sortedArrayToBSTRecu(self, num, start, end):
         if start == end:
             return None
-        mid = start + (end - start) / 2
+        mid = start + self.perfect_tree_pivot(end - start)
         node = TreeNode(num[mid])
         node.left = self.sortedArrayToBSTRecu(num, start, mid)
         node.right = self.sortedArrayToBSTRecu(num, mid + 1, end)


### PR DESCRIPTION
Given a list [1,2,3,4,5], the previous solution will create this:
      3
   /    \ 
  2     4
/       /
1      5

But a complete perfect BST should look like this:
      4
   /    \ 
  3     5
 /  \ 
1    2

There are two cases: Either

case 1: the left subtree of the root is perfect and the right subtree has less nodes or
case 2: the left subtree of the root has more nodes and the right subtree is perfect.
In both cases the number of nodes in the perfect subtree is some 2**d - 1 so the root is the 2**dth node counting from the left (case 1) or the right (case 2)