### PR TITLE
Update strobogrammatic-number.py

### DIFF
--- a/Python/strobogrammatic-number.py
+++ b/Python/strobogrammatic-number.py
@@ -12,5 +12,4 @@ class Solution:
             if num[n-1-i] not in self.lookup or \
                num[i] != self.lookup[num[n-1-i]]:
                 return False
-            i += 1
         return True


### PR DESCRIPTION
It doesn't need `i += 1`. Based on git blame, it seems it was accidentally added.