### PR TITLE
Update lru-cache.py

### DIFF
--- a/Python/lru-cache.py
+++ b/Python/lru-cache.py
@@ -55,7 +55,8 @@ class LinkedList(object):
             node.next.prev = node.prev
         else:
             self.tail = node.prev
-        del node
+        node.next = None
+        node.prev = None
 
 class LRUCache(object):
 


### PR DESCRIPTION
With 'del node', the following code (repeatedly inserting and removing the same Node) will go into an infinite loop.

l = LinkedList()
one=ListNode('a',1)
two=ListNode('b',2)
three=ListNode('c',3)
four=ListNode('d',4)
l.insert(one)
l.insert(two)
l.insert(three)
l.insert(four)
print (l)
l.remove(three)
print (l)
l.insert(three) #This will be a problem with 'del Node' because the Node outside the func is untouched but now has next and prev pointers.
print (l)