### PR TITLE
set global_max start with 0

### DIFF
--- a/Python/maximum-subarray.py
+++ b/Python/maximum-subarray.py
@@ -20,7 +20,7 @@ class Solution(object):
         """
         if max(nums) < 0:
             return max(nums)
-        global_max, local_max = float("-inf"), 0
+        global_max, local_max = 0, 0
         for x in nums:
             local_max = max(0, local_max + x)
             global_max = max(global_max, local_max)


### PR DESCRIPTION
There is no need to start global_max with float('-inf'), set it to 0 will work as well.
As local_max will never be smaller than 0, so global max will also start from 0.
The only thing float('-inf') to prevent is when all elements in [nums] are negative numbers, but the first 'if' condition has ruled that out.